### PR TITLE
Use idiomatic forms of marshal/unmarshal

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@ and `refmt/json` and `refmt/cbor` as ways to exchange tokens with serialized for
 
 All of these formats can mix-n-match freely, because they communicate values as the standard token stream. Voilà:
 
-- pair `obj.Marshaller` with `json.Encoder` to get a json serializer.
-- pair `cbor.Decoder` with `obj.Unmarshaller` to get a cbor deserializer.
+- pair `obj.Marshaler` with `json.Encoder` to get a json serializer.
+- pair `cbor.Decoder` with `obj.Unmarshaler` to get a cbor deserializer.
 - pair `cbor.Decoder` with `json.Encoder` to get a cbor->json streaming transcoder!
-- pair `obj.Marshaller` with `obj.Unmarshaller` to get a deep-copy system!  (Try it with two different types: marshalling a struct and unmarshalling into a freeform map!)
+- pair `obj.Marshaler` with `obj.Unmarshaler` to get a deep-copy system!  (Try it with two different types: marshaling a struct and unmarshaling into a freeform map!)
 
 Along the way, we've added a powerful system for defining **how** exactly the `refmt/obj` tools should treat your structures:
 the Atlas system (defined in the `refmt/obj/atlas` package).
 Atlases can be used to customize how struct fields are handled, how map keys are sorted, and even
 define conversions between completely different *kinds* of objects: serialize arrays as strings, or turn stringy enums into bitfields, no problem.
-By default, `refmt` will generate atlases automatically for your structs and types, just like the standard library json marshallers do;
+By default, `refmt` will generate atlases automatically for your structs and types, just like the standard library json marshalers do;
 if you want more control, atlases give you the power.
 
-An Atlas can be given to each `obj.Marshaller` and `obj.Unmarshaller` when it is constructed.
+An Atlas can be given to each `obj.Marshaler` and `obj.Unmarshaler` when it is constructed.
 This allows great variation in how you wish to handle types -- more than one mapping can be defined for the same concrete type!
 (This is a killer feature if you need to support multiple versions of an API, for example:
 you can define 'v1' and 'v2' types, each with their own structs to unmarshal user requests into;
@@ -46,9 +46,9 @@ Atlases attach to the type they concern.
 This means you can use atlases to define custom serialization even for types in packages you can't modify!
 Atlases also behave better in complex situations: for example,
 if you have a `TypeFoo` struct and you wish to serialize it as a string,
-*you don't have to write a custom marshaller for every type that **contains** a `TypeFoo` field*.
+*you don't have to write a custom marshaler for every type that **contains** a `TypeFoo` field*.
 Leaking details of custom serialization into the types that contain the interesting objects is
-a common pitfall when getting into advanced usage of other marshalling libraries; `refmt` has no such issue.
+a common pitfall when getting into advanced usage of other marshaling libraries; `refmt` has no such issue.
 
 ## tl;dr:
 

--- a/doc.go
+++ b/doc.go
@@ -4,9 +4,9 @@
 	Look to the README on github for more high-level information.
 
 	This top-level package exposes simple helper methods for most common operations.
-	You can also compose custom marshallers/unmarshallers and serializer/deserializers
+	You can also compose custom marshalers/unmarshalers and serializer/deserializers
 	by constructing a `refmt.TokenPump` with components from the packages beneath this one.
 	For example, the `refmt.JsonEncode` helper method can be replicated by combining
-	an `obj.Marshaller` with a `json.Encoder`.
+	an `obj.Marshaler` with a `json.Encoder`.
 */
 package refmt

--- a/docs/dev/code-layout.md
+++ b/docs/dev/code-layout.md
@@ -7,8 +7,8 @@ Package layout
 - `refmt` -- main package.  All major interface types and helpful factory methods.
   - `json` -- `json.Serializer` and `json.Deserializer`
   - `cbor` -- `cbor.Serializer` and `cbor.Deserializer`
-  - `obj` -- `obj.Marshaller` and `obj.Unmarshaller`
-    - `atlas` -- types for describing how to `obj.*Marshaller`s should visit complex types.
+  - `obj` -- `obj.Marshaler` and `obj.Unmarshaler`
+    - `atlas` -- types for describing how to `obj.*Marshaler`s should visit complex types.
   - `tok` -- token handling utils.  Many exported values, for use in sibling packages, but not often seen by users.
 
 (Experienced go developers will probably already have noticed that putting core interfaces and factory methods in the same package is usually going to run aground on the no-cyclic-imports rule.
@@ -23,7 +23,7 @@ User-facing
   refmt.NewJsonEncoder(stdout).Marshal(123)
   ```
   - Creates an `obj.Marshaler` as the `refmt.TokenSource` for walking the object (`123`).
-  - Creates a `json.Marshaller` as the `refmt.TokenSink` outputting to `stdout`.
+  - Creates a `json.Marshaler` as the `refmt.TokenSink` outputting to `stdout`.
   - Both are placed into a `refmt.TokenPump`, which powers the rest of the transaction.
   - The `obj.Marshaler` sees the type of object it was given and immediately delegates to an `obj.marshalMachineLiteral`.
   - The `obj.marshalMachineLiteral` steps once, yields a token (it's going to be `TokenType` of `TInt`), and reports done.  There are no other stacked machines, so the `obj.Marshaler` overall reports done.

--- a/helpers_cbor.go
+++ b/helpers_cbor.go
@@ -15,24 +15,24 @@ func NewCborEncoder(wr io.Writer) *CborEncoder {
 
 func NewAtlasedCborEncoder(wr io.Writer, atl atlas.Atlas) *CborEncoder {
 	enc := &CborEncoder{
-		marshaller: obj.NewMarshaler(atl),
+		marshaler: obj.NewMarshaler(atl),
 		encoder:    cbor.NewEncoder(wr),
 	}
 	enc.pump = TokenPump{
-		enc.marshaller,
+		enc.marshaler,
 		enc.encoder,
 	}
 	return enc
 }
 
 type CborEncoder struct {
-	marshaller *obj.Marshaler
+	marshaler *obj.Marshaler
 	encoder    *cbor.Encoder
 	pump       TokenPump
 }
 
 func (d *CborEncoder) Marshal(v interface{}) error {
-	d.marshaller.Bind(v)
+	d.marshaler.Bind(v)
 	d.encoder.Reset()
 	return d.pump.Run()
 }

--- a/helpers_cborLegacy_test.go
+++ b/helpers_cborLegacy_test.go
@@ -17,24 +17,24 @@ func NewCborLegacyEncoder(wr io.Writer) *CborLegacyEncoder {
 
 func NewAtlasedCborLegacyEncoder(wr io.Writer, suite *objLegacy.Suite) *CborLegacyEncoder {
 	enc := &CborLegacyEncoder{
-		marshaller: objLegacy.NewMarshaler(suite),
+		marshaler: objLegacy.NewMarshaler(suite),
 		encoder:    cbor.NewEncoder(wr),
 	}
 	enc.pump = TokenPump{
-		enc.marshaller,
+		enc.marshaler,
 		enc.encoder,
 	}
 	return enc
 }
 
 type CborLegacyEncoder struct {
-	marshaller *objLegacy.MarshalDriver
+	marshaler *objLegacy.MarshalDriver
 	encoder    *cbor.Encoder
 	pump       TokenPump
 }
 
 func (d *CborLegacyEncoder) Marshal(v interface{}) error {
-	d.marshaller.Bind(v)
+	d.marshaler.Bind(v)
 	d.encoder.Reset()
 	return d.pump.Run()
 }

--- a/helpers_json.go
+++ b/helpers_json.go
@@ -15,24 +15,24 @@ func NewJsonEncoder(wr io.Writer) *JsonEncoder {
 
 func NewAtlasedJsonEncoder(wr io.Writer, atl atlas.Atlas) *JsonEncoder {
 	enc := &JsonEncoder{
-		marshaller: obj.NewMarshaler(atl),
+		marshaler: obj.NewMarshaler(atl),
 		encoder:    json.NewEncoder(wr),
 	}
 	enc.pump = TokenPump{
-		enc.marshaller,
+		enc.marshaler,
 		enc.encoder,
 	}
 	return enc
 }
 
 type JsonEncoder struct {
-	marshaller *obj.Marshaler
+	marshaler *obj.Marshaler
 	encoder    *json.Encoder
 	pump       TokenPump
 }
 
 func (d *JsonEncoder) Marshal(v interface{}) error {
-	d.marshaller.Bind(v)
+	d.marshaler.Bind(v)
 	d.encoder.Reset()
 	return d.pump.Run()
 }

--- a/helpers_jsonLegacy_test.go
+++ b/helpers_jsonLegacy_test.go
@@ -17,24 +17,24 @@ func NewJsonLegacyEncoder(wr io.Writer) *JsonLegacyEncoder {
 
 func NewAtlasedJsonLegacyEncoder(wr io.Writer, suite *objLegacy.Suite) *JsonLegacyEncoder {
 	enc := &JsonLegacyEncoder{
-		marshaller: objLegacy.NewMarshaler(suite),
+		marshaler: objLegacy.NewMarshaler(suite),
 		encoder:    json.NewEncoder(wr),
 	}
 	enc.pump = TokenPump{
-		enc.marshaller,
+		enc.marshaler,
 		enc.encoder,
 	}
 	return enc
 }
 
 type JsonLegacyEncoder struct {
-	marshaller *objLegacy.MarshalDriver
+	marshaler *objLegacy.MarshalDriver
 	encoder    *json.Encoder
 	pump       TokenPump
 }
 
 func (d *JsonLegacyEncoder) Marshal(v interface{}) error {
-	d.marshaller.Bind(v)
+	d.marshaler.Bind(v)
 	d.encoder.Reset()
 	return d.pump.Run()
 }

--- a/obj/atlas/atlas.go
+++ b/obj/atlas/atlas.go
@@ -110,10 +110,10 @@ type AtlasEntry struct {
 	// --------------------------------------------------------
 
 	// A validation function which will be called for the whole value
-	// after unmarshalling reached the end of the object.
+	// after unmarshaling reached the end of the object.
 	// If it returns an error, the entire unmarshal will error.
 	//
-	// Not used in marshalling.
+	// Not used in marshaling.
 	// Not reachable if an UnmarshalTransform is set.
 	ValidateFn func(v interface{}) error
 }

--- a/obj/atlas/structMap.go
+++ b/obj/atlas/structMap.go
@@ -21,7 +21,7 @@ type StructMapEntry struct {
 	// Theoretical feature which would be alternative to ReflectRoute.  Support dropped for the moment.
 	//addrFunc     func(interface{}) interface{} // custom user function.
 
-	// If true, marshalling will skip this field if its the zero value.
+	// If true, marshaling will skip this field if its the zero value.
 	OmitEmpty bool
 }
 

--- a/obj/errors.go
+++ b/obj/errors.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ErrInvalidUnmarshalTarget describes an invalid argument passed to Unmarshaler.Bind.
-// (Unmarshalling must target a non-nil pointer so that it can address the value.)
+// (Unmarshaling must target a non-nil pointer so that it can address the value.)
 type ErrInvalidUnmarshalTarget struct {
 	Type reflect.Type
 }
@@ -23,7 +23,7 @@ func (e ErrInvalidUnmarshalTarget) Error() string {
 	return "unmarshal error: invalid target (nil " + e.Type.String() + ")"
 }
 
-// ErrUnmarshalTypeCantFit is the error returned when unmarshalling cannot
+// ErrUnmarshalTypeCantFit is the error returned when unmarshaling cannot
 // coerce the tokens in the stream into the kind of variables the unmarshal is targetting,
 // for example if a map open token comes when an int is expected,
 // or an int token comes when a string is expected.
@@ -36,7 +36,7 @@ func (e ErrUnmarshalTypeCantFit) Error() string {
 	return fmt.Sprintf("unmarshal error: cannot assign %s to %s field", e.Token, e.Value.Kind())
 }
 
-// ErrMalformedTokenStream is the error returned when unmarshalling recieves a
+// ErrMalformedTokenStream is the error returned when unmarshaling recieves a
 // completely invalid transition, such as when a map value is expected, but the
 // map suddenly closes, or an array close is recieved with no matching array open.
 type ErrMalformedTokenStream struct {
@@ -48,7 +48,7 @@ func (e ErrMalformedTokenStream) Error() string {
 	return fmt.Sprintf("malformed stream: invalid appearance of %s token; expected %s", e.Got, e.Expected)
 }
 
-// ErrNoSuchField is the error returned when unmarshalling into a struct and
+// ErrNoSuchField is the error returned when unmarshaling into a struct and
 // the token stream for the map contains a key which is not defined for the struct.
 type ErrNoSuchField struct {
 	Name string // Field name from the token.

--- a/obj/marshal.go
+++ b/obj/marshal.go
@@ -76,7 +76,7 @@ func (d *Marshaler) Step(tok *Token) (bool, error) {
 }
 
 /*
-	Starts the process of recursing marshalling over value `rv`.
+	Starts the process of recursing marshaling over value `rv`.
 
 	Caller provides the machine to use (this is an optimization for maps and slices,
 	which already know the machine and keep reusing it for all their entries).

--- a/obj/objFixtures_test.go
+++ b/obj/objFixtures_test.go
@@ -16,7 +16,7 @@ var skipMe = fmt.Errorf("skipme")
 
 type marshalResults struct {
 	title string
-	// Yields a value to hand to the marshaller.
+	// Yields a value to hand to the marshaler.
 	// A func returning a wildcard is used rather than just an `interface{}`, because `&target` conveys very different type information.
 	valueFn func() interface{}
 
@@ -25,7 +25,7 @@ type marshalResults struct {
 }
 type unmarshalResults struct {
 	title string
-	// Yields the handle we should give to the unmarshaller to fill.
+	// Yields the handle we should give to the unmarshaler to fill.
 	// Like `valueFn`, the indirection here is to help
 	slotFn func() interface{}
 
@@ -77,7 +77,7 @@ var objFixtures = []struct {
 	// The suite of mappings to use.
 	atlas atlas.Atlas
 
-	// The results to expect from various marshalling starting points.
+	// The results to expect from various marshaling starting points.
 	// This is a slice because we occasionally have several different kinds of objects
 	// which we expect will converge on the same token fixture given the same atlas.
 	marshalResults []marshalResults
@@ -282,7 +282,7 @@ var objFixtures = []struct {
 				valueFn: func() interface{} { return tObjStr2{"value", "v2"} }},
 		},
 	},
-	{title: "object with two string fields, with atlas entry, unmarshalling accepts alt2 serial ordering",
+	{title: "object with two string fields, with atlas entry, unmarshaling accepts alt2 serial ordering",
 		sequence: fixtures.SequenceMap["duo row map alt2"],
 		atlas: atlas.MustBuild(
 			atlas.BuildEntry(tObjStr2{}).StructMap().
@@ -305,7 +305,7 @@ var objFixtures = []struct {
 				valueFn: func() interface{} { return tObjStr2{"value", "v2"} }},
 		},
 	},
-	{title: "object with two string fields, with atlas entry, unmarshalling rejects when fields mismatch",
+	{title: "object with two string fields, with atlas entry, unmarshaling rejects when fields mismatch",
 		sequence: fixtures.SequenceMap["duo row map"],
 		atlas: atlas.MustBuild(
 			atlas.BuildEntry(tObjStr2{}).StructMap().
@@ -800,7 +800,7 @@ var objFixtures = []struct {
 				valueFn: func() interface{} { return []int(nil) }},
 			{title: "into *tObjStr",
 				slotFn: func() interface{} { var v tObjStr; return &v },
-				// no, the answer is *not* a nil a la `{ var v *tObjStr; return v }` -- because the way unmarshalling uses the first pointer, it can't really set it to nil.
+				// no, the answer is *not* a nil a la `{ var v *tObjStr; return v }` -- because the way unmarshaling uses the first pointer, it can't really set it to nil.
 				// stdlib json behavior is the same for the same reasons: https://play.golang.org/p/kd8iqNPdlM
 				valueFn: func() interface{} { return tObjStr{""} }},
 		},
@@ -860,7 +860,7 @@ var objFixtures = []struct {
 	},
 }
 
-func TestMarshaller(t *testing.T) {
+func TestMarshaler(t *testing.T) {
 	// Package all the values from one step into a struct, just so that
 	// we can assert on them all at once and make one green checkmark render per step.
 	// Stringify the token first so extraneous fields in the union are hidden.
@@ -869,7 +869,7 @@ func TestMarshaller(t *testing.T) {
 		err error
 	}
 
-	Convey("Marshaller suite:", t, func() {
+	Convey("Marshaler suite:", t, func() {
 		for _, tr := range objFixtures {
 			Convey(fmt.Sprintf("%q fixture sequence:", tr.title), func() {
 				for _, trr := range tr.marshalResults {
@@ -881,16 +881,16 @@ func TestMarshaller(t *testing.T) {
 					value := trr.valueFn()
 					valueKind := reflect.ValueOf(value).Kind()
 					maybe(fmt.Sprintf("working %s (%s|%T):", trr.title, valueKind, value), func() {
-						// Set up marshaller.
-						marshaller := NewMarshaler(tr.atlas)
-						marshaller.Bind(value)
+						// Set up marshaler.
+						marshaler := NewMarshaler(tr.atlas)
+						marshaler.Bind(value)
 
 						Convey("Steps...", func() {
-							// Run steps until the marshaller says done or error.
+							// Run steps until the marshaler says done or error.
 							// For each step, assert the token matches fixtures;
 							// when error and expected one, skip token check on that step
 							// and finalize with the assertion.
-							// If marshaller doesn't stop when we expected it to based
+							// If marshaler doesn't stop when we expected it to based
 							// on fixture length, let it keep running three more steps
 							// so we get that much more debug info.
 							var done bool
@@ -898,7 +898,7 @@ func TestMarshaller(t *testing.T) {
 							var tok Token
 							expectSteps := len(tr.sequence.Tokens) - 1
 							for nStep := 0; nStep < expectSteps+3; nStep++ {
-								done, err = marshaller.Step(&tok)
+								done, err = marshaler.Step(&tok)
 								if err != nil && trr.expectErr != nil {
 									Convey("Result (error expected)", func() {
 										So(err.Error(), ShouldResemble, trr.expectErr.Error())
@@ -933,7 +933,7 @@ func TestMarshaller(t *testing.T) {
 	})
 }
 
-func TestUnmarshaller(t *testing.T) {
+func TestUnmarshaler(t *testing.T) {
 	// Package all the values from one step into a struct, just so that
 	// we can assert on them all at once and make one green checkmark render per step.
 	// Stringify the token first so extraneous fields in the union are hidden.
@@ -943,7 +943,7 @@ func TestUnmarshaller(t *testing.T) {
 		done bool
 	}
 
-	Convey("Unmarshaller suite:", t, func() {
+	Convey("Unmarshaler suite:", t, func() {
 		for _, tr := range objFixtures {
 			Convey(fmt.Sprintf("%q fixture sequence:", tr.title), func() {
 				for _, trr := range tr.unmarshalResults {
@@ -956,9 +956,9 @@ func TestUnmarshaller(t *testing.T) {
 					slotKind := reflect.ValueOf(slot).Kind()
 					maybe(fmt.Sprintf("targetting %s (%s|%T):", trr.title, slotKind, slot), func() {
 
-						// Set up unmarshaller.
-						unmarshaller := NewUnmarshaler(tr.atlas)
-						err := unmarshaller.Bind(slot)
+						// Set up unmarshaler.
+						unmarshaler := NewUnmarshaler(tr.atlas)
+						err := unmarshaler.Bind(slot)
 						if err != nil && trr.expectErr != nil {
 							Convey("Result (error expected)", func() {
 								So(err.Error(), ShouldResemble, trr.expectErr.Error())
@@ -968,13 +968,13 @@ func TestUnmarshaller(t *testing.T) {
 
 						Convey("Steps...", func() {
 							// Run steps.
-							// This is less complicated than the marshaller test
+							// This is less complicated than the marshaler test
 							// because we know exactly when we'll run out of them.
 							var done bool
 							var err error
 							expectSteps := len(tr.sequence.Tokens) - 1
 							for nStep, tok := range tr.sequence.Tokens {
-								done, err = unmarshaller.Step(&tok)
+								done, err = unmarshaler.Step(&tok)
 								if err != nil && trr.expectErr != nil {
 									Convey("Result (error expected)", func() {
 										So(err.Error(), ShouldResemble, trr.expectErr.Error())

--- a/obj/unmarshal.go
+++ b/obj/unmarshal.go
@@ -77,7 +77,7 @@ func (d *Unmarshaler) Step(tok *Token) (bool, error) {
 }
 
 /*
-	Starts the process of recursing unmarshalling over value `rv`.
+	Starts the process of recursing unmarshaling over value `rv`.
 
 	Caller provides the machine to use (this is an optimization for maps and slices,
 	which already know the machine and keep reusing it for all their entries).

--- a/objLegacy/atlas/atlas.go
+++ b/objLegacy/atlas/atlas.go
@@ -36,7 +36,7 @@ type Entry struct {
 	// TODO this is one of {Atlas, func()(Atlas), or TokenSourceMachine|TokenSinkMachine}
 	//  the latter is certainly the most correct, but also pretty wicked to export publicly
 
-	// If true, marshalling will skip this field if its the zero value.
+	// If true, marshaling will skip this field if its the zero value.
 	// (If you need more complex behavior -- for example, a definition of
 	// "empty" other than the type's zero value -- this is not for you.
 	// Try using an AtlasFactory to make a custom field list dynamically.)

--- a/objLegacy/errors.go
+++ b/objLegacy/errors.go
@@ -11,7 +11,7 @@ var (
 )
 
 /*
-	Error raised as a panic when marshalling or unmarshalling an object, and
+	Error raised as a panic when marshaling or unmarshaling an object, and
 	no handler can be found for a referenced type.
 */
 type ErrNoHandler struct {

--- a/objLegacy/marshal.go
+++ b/objLegacy/marshal.go
@@ -70,7 +70,7 @@ func (d *MarshalDriver) Step(tok *Token) (bool, error) {
 }
 
 /*
-	Starts the process of recursing marshalling over `target` value.
+	Starts the process of recursing marshaling over `target` value.
 
 	Caller provides the machine to use (this is an optimization for maps and slices,
 	which already know the machine and keep reusing it for all their entries).

--- a/objLegacy/marshalMachineStructAtlas_test.go
+++ b/objLegacy/marshalMachineStructAtlas_test.go
@@ -93,15 +93,15 @@ func TestMarshalMachineStructAtlas(t *testing.T) {
 		suite.Add(tgt, Morphism{Atlas: tr.atlas})
 
 		err := CapturePanics(func() {
-			marshaller := NewMarshaler(suite)
-			marshaller.Bind(tgt)
+			marshaler := NewMarshaler(suite)
+			marshaler.Bind(tgt)
 
 			// Run steps.
 			var done bool
 			var err error
 			var tok Token
 			for n, expectTok := range tr.expectSeq {
-				done, err = marshaller.Step(&tok)
+				done, err = marshaler.Step(&tok)
 				if !IsTokenEqual(expectTok, tok) {
 					t.Errorf("test %q failed: step %d yielded wrong token: expected %s, got %s",
 						tr.title, n, expectTok, tok)

--- a/objLegacy/marshal_test.go
+++ b/objLegacy/marshal_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/polydawn/refmt/tok"
 )
 
-func TestMarshaller(t *testing.T) {
+func TestMarshaler(t *testing.T) {
 	type NN struct {
 		F int
 		X string
@@ -362,15 +362,15 @@ func TestMarshaller(t *testing.T) {
 			tr.suite = &Suite{}
 		}
 		err := CapturePanics(func() {
-			marshaller := NewMarshaler(tr.suite)
-			marshaller.Bind(tr.targetFn())
+			marshaler := NewMarshaler(tr.suite)
+			marshaler.Bind(tr.targetFn())
 
 			// Run steps.
 			var done bool
 			var err error
 			var tok Token
 			for n, expectTok := range tr.expectSeq {
-				done, err = marshaller.Step(&tok)
+				done, err = marshaler.Step(&tok)
 				if !IsTokenEqual(expectTok, tok) {
 					t.Errorf("test %q failed: step %d yielded wrong token: expected %s, got %s",
 						tr.title, n, expectTok, tok)

--- a/objLegacy/unmarshal_test.go
+++ b/objLegacy/unmarshal_test.go
@@ -24,7 +24,7 @@ func (s *slotForIface) Slot() interface{}              { return &s.slot }
 func (s *slotForSliceOfIface) Slot() interface{}       { return &s.slot }
 func (s *slotForMapOfStringToIface) Slot() interface{} { return &s.slot }
 
-func TestUnmarshaller(t *testing.T) {
+func TestUnmarshaler(t *testing.T) {
 	tt := []struct {
 		title    string
 		slotter  slotter

--- a/tok/fixtures/fixtures.go
+++ b/tok/fixtures/fixtures.go
@@ -56,7 +56,7 @@ var Sequences = []Sequence{
 		},
 	},
 	{"duo row map alt2",
-		// same as previous, but map entries in a different order -- useful to test that unmarshaller can accept that (or, reject non-canonical orders!)
+		// same as previous, but map entries in a different order -- useful to test that unmarshaler can accept that (or, reject non-canonical orders!)
 		[]Token{
 			{Type: TMapOpen, Length: 2},
 			TokStr("k2"),


### PR DESCRIPTION
Addresses #3 

Go uses a single L in the usage of the words marshal and unmarshal.
We should follow that pattern consistently to avoid confusion.

Signed-off-by: Calvin Behling <calvin.behling@gmail.com>