### PR TITLE
refmt now supports maps with keys of type struct (given proper configuration)

### DIFF
--- a/obj/marshalMapWildcard.go
+++ b/obj/marshalMapWildcard.go
@@ -12,12 +12,13 @@ import (
 type marshalMachineMapWildcard struct {
 	morphism *atlas.MapMorphism // set on initialization
 
-	target_rv reflect.Value
-	value_rt  reflect.Type
-	valueMach MarshalMachine
-	keys      []wildcardMapStringyKey
-	index     int
-	value     bool
+	target_rv   reflect.Value
+	value_rt    reflect.Type
+	keyStringer atlas.MarshalTransformFunc
+	valueMach   MarshalMachine
+	keys        []wildcardMapStringyKey
+	index       int
+	value       bool
 }
 
 func (mach *marshalMachineMapWildcard) Reset(slab *marshalSlab, rv reflect.Value, rt reflect.Type) error {
@@ -38,6 +39,17 @@ func (mach *marshalMachineMapWildcard) Reset(slab *marshalSlab, rv reflect.Value
 		//  tostring themach.  but this is not supported symmetrically; so we simply... don't.
 		//  we could also consider supporting anything that uses a MarshalTransformFunc
 		//  to become a string kind; that's a fair bit of code, perhaps later.
+		mach.keyStringer = nil
+	case reflect.Struct:
+		// composite keys requires some fancy footwork, but we can do it.
+		// Interestingly enough, we don't need full-on machinery here; because the
+		//  tokenized form is restricted to being a string, the transform func is enough.
+		rtid := reflect.ValueOf(key_rt).Pointer()
+		atlEnt, ok := slab.atlas.Get(rtid)
+		if !ok || atlEnt.MarshalTransformTargetType.Kind() != reflect.String {
+			return fmt.Errorf("unsupported map key type %q (if you want to use struct keys, your atlas needs a transform to string)", key_rt.Name())
+		}
+		mach.keyStringer = atlEnt.MarshalTransformFunc
 	default:
 		return fmt.Errorf("unsupported map key type %q", key_rt.Name())
 	}
@@ -45,7 +57,15 @@ func (mach *marshalMachineMapWildcard) Reset(slab *marshalSlab, rv reflect.Value
 	mach.keys = make([]wildcardMapStringyKey, len(keys_rv))
 	for i, v := range keys_rv {
 		mach.keys[i].rv = v
-		mach.keys[i].s = v.String()
+		if mach.keyStringer == nil {
+			mach.keys[i].s = v.String()
+		} else {
+			trans_rv, err := mach.keyStringer(v)
+			if err != nil {
+				return fmt.Errorf("unsupported map key type %q: errors in stringifying: %s", key_rt.Name(), err)
+			}
+			mach.keys[i].s = trans_rv.String()
+		}
 	}
 
 	ksm := atlas.KeySortMode_Default

--- a/obj/marshalMapWildcard.go
+++ b/obj/marshalMapWildcard.go
@@ -46,7 +46,7 @@ func (mach *marshalMachineMapWildcard) Reset(slab *marshalSlab, rv reflect.Value
 		//  tokenized form is restricted to being a string, the transform func is enough.
 		rtid := reflect.ValueOf(key_rt).Pointer()
 		atlEnt, ok := slab.atlas.Get(rtid)
-		if !ok || atlEnt.MarshalTransformTargetType.Kind() != reflect.String {
+		if !ok || atlEnt.MarshalTransformTargetType == nil || atlEnt.MarshalTransformTargetType.Kind() != reflect.String {
 			return fmt.Errorf("unsupported map key type %q (if you want to use struct keys, your atlas needs a transform to string)", key_rt.Name())
 		}
 		mach.keyStringer = atlEnt.MarshalTransformFunc

--- a/obj/objSuite_map_test.go
+++ b/obj/objSuite_map_test.go
@@ -1,0 +1,54 @@
+package obj
+
+import (
+	"testing"
+
+	"github.com/polydawn/refmt/obj/atlas"
+	"github.com/polydawn/refmt/tok/fixtures"
+)
+
+func TestMapHandling(t *testing.T) {
+	t.Run("tokens for map with one string field", func(t *testing.T) {
+		seq := fixtures.SequenceMap["single row map"].Tokens
+		t.Run("prism to map[string]string", func(t *testing.T) {
+			atlas := atlas.MustBuild()
+			t.Run("marshal", func(t *testing.T) {
+				value := map[string]string{"key": "value"}
+				checkMarshalling(t, atlas, value, seq, nil)
+				checkMarshalling(t, atlas, &value, seq, nil)
+			})
+			t.Run("unmarshal", func(t *testing.T) {
+				slot := map[string]string{}
+				expect := map[string]string{"key": "value"}
+				checkUnmarshalling(t, atlas, &slot, seq, &expect, nil)
+			})
+		})
+		t.Run("prism to map[TransformedStruct]string", func(t *testing.T) {
+			type Keyish struct {
+				Key string
+			}
+			atl := atlas.MustBuild(
+				atlas.BuildEntry(Keyish{}).Transform().
+					TransformMarshal(atlas.MakeMarshalTransformFunc(
+						func(x Keyish) (string, error) {
+							return x.Key, nil
+						})).
+					TransformUnmarshal(atlas.MakeUnmarshalTransformFunc(
+						func(x string) (Keyish, error) {
+							return Keyish{x}, nil
+						})).
+					Complete(),
+			)
+			t.Run("marshal", func(t *testing.T) {
+				value := map[Keyish]string{{"key"}: "value"}
+				checkMarshalling(t, atl, value, seq, nil)
+				checkMarshalling(t, atl, &value, seq, nil)
+			})
+			t.Run("unmarshal", func(t *testing.T) {
+				slot := map[Keyish]string{}
+				expect := map[Keyish]string{{"key"}: "value"}
+				checkUnmarshalling(t, atl, &slot, seq, &expect, nil)
+			})
+		})
+	})
+}

--- a/obj/unmarshalMapWildcard.go
+++ b/obj/unmarshalMapWildcard.go
@@ -28,7 +28,7 @@ func (mach *unmarshalMachineMapStringWildcard) Reset(slab *unmarshalSlab, rv ref
 	if mach.key_rv.Kind() != reflect.String {
 		rtid := reflect.ValueOf(key_rt).Pointer()
 		atlEnt, ok := slab.atlas.Get(rtid)
-		if !ok || atlEnt.UnmarshalTransformTargetType.Kind() != reflect.String {
+		if !ok || atlEnt.UnmarshalTransformTargetType == nil || atlEnt.UnmarshalTransformTargetType.Kind() != reflect.String {
 			return fmt.Errorf("unsupported map key type %q (if you want to use struct keys, your atlas needs a transform from string)", key_rt.Name())
 		}
 		mach.keyDestringer = atlEnt.UnmarshalTransformFunc

--- a/obj/unmarshalMapWildcard.go
+++ b/obj/unmarshalMapWildcard.go
@@ -4,24 +4,35 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/polydawn/refmt/obj/atlas"
 	. "github.com/polydawn/refmt/tok"
 )
 
 type unmarshalMachineMapStringWildcard struct {
-	target_rv reflect.Value    // Handle to the map.  Can set to zero, or set k=v pairs into, etc.
-	value_rt  reflect.Type     // Type info for map values (cached for convenience in recurse calls).
-	valueMach UnmarshalMachine // Machine for map values.
-	key_rv    reflect.Value    // Addressable handle to a slot for keys to unmarshal into.
-	tmp_rv    reflect.Value    // Addressable handle to a slot for values to unmarshal into.
-	step      unmarshalMachineStep
-	haveValue bool // Piece of attendant state to help know we've been through at least one k=v pair so we can post-v store it.
+	target_rv     reflect.Value                // Handle to the map.  Can set to zero, or set k=v pairs into, etc.
+	value_rt      reflect.Type                 // Type info for map values (cached for convenience in recurse calls).
+	valueMach     UnmarshalMachine             // Machine for map values.
+	key_rv        reflect.Value                // Addressable handle to a slot for keys to unmarshal into.
+	keyDestringer atlas.UnmarshalTransformFunc // Transform str->foo, to be used if keys are not plain strings.
+	tmp_rv        reflect.Value                // Addressable handle to a slot for values to unmarshal into.
+	step          unmarshalMachineStep
+	haveValue     bool // Piece of attendant state to help know we've been through at least one k=v pair so we can post-v store it.
 }
 
 func (mach *unmarshalMachineMapStringWildcard) Reset(slab *unmarshalSlab, rv reflect.Value, rt reflect.Type) error {
 	mach.target_rv = rv
 	mach.value_rt = rt.Elem()
 	mach.valueMach = slab.requisitionMachine(mach.value_rt)
-	mach.key_rv = reflect.New(rt.Key()).Elem()
+	key_rt := rt.Key()
+	mach.key_rv = reflect.New(key_rt).Elem()
+	if mach.key_rv.Kind() != reflect.String {
+		rtid := reflect.ValueOf(key_rt).Pointer()
+		atlEnt, ok := slab.atlas.Get(rtid)
+		if !ok || atlEnt.UnmarshalTransformTargetType.Kind() != reflect.String {
+			return fmt.Errorf("unsupported map key type %q (if you want to use struct keys, your atlas needs a transform from string)", key_rt.Name())
+		}
+		mach.keyDestringer = atlEnt.UnmarshalTransformFunc
+	}
 	mach.tmp_rv = reflect.New(mach.value_rt).Elem()
 	mach.step = mach.step_Initial
 	mach.haveValue = false
@@ -79,7 +90,15 @@ func (mach *unmarshalMachineMapStringWildcard) step_AcceptKey(_ *Unmarshaller, s
 	case TArrClose:
 		return true, fmt.Errorf("unexpected arrClose; expected map key")
 	case TString:
-		mach.key_rv.SetString(tok.Str)
+		if mach.keyDestringer != nil {
+			key_rv, err := mach.keyDestringer(reflect.ValueOf(tok.Str))
+			if err != nil {
+				return true, fmt.Errorf("unsupported map key type %q: errors in stringifying: %s", mach.key_rv.Type().Name(), err)
+			}
+			mach.key_rv.Set(key_rv)
+		} else {
+			mach.key_rv.SetString(tok.Str)
+		}
 		if err = mach.mustAcceptKey(mach.key_rv); err != nil {
 			return true, err
 		}


### PR DESCRIPTION
Go allows structs to be the keys of maps (given a series of caveats; no ptrs, etc, or any other hijinx that would make the keys *incomparable*).

Refmt is going to remain a little more straightjacketed than that in serial form; non-string keys are still an invitation for trouble in any broadly cross-language/cross-format system.  Struct keys in maps *obviously* do not work in JSON, for example.

**But that's not to say we can't *transform* the serialized keys into other types when we marshal and unmarshal into Go types!**

So now, **we can**.  As long as your map key type is *either* a String kind (as usual) or (:new:) your atlas provides transformation functions to convert your key type to String kinds, then we'll do so: those structs will be flipped into strings for marshalling (and the order of map entries emitted will be sorted on the string form, as usual) and in unmarshalling the strings will be quietly flipped back into structs.

(This is a feature I get a *ton* of utility out of in the [Repeatr](https://github.com/polydawn/repeatr) project & the [Timeless Stack APIs](https://github.com/polydawn/go-timeless-api) -- lots of things are strings by design to keep the serial API simple (e.g., pipe through `jq` and get what you want), but make the most sense internally to the code when treated as a struct with a couple of fields.  Now having your cake and eating it too is easy!)

Usage looks like this:

```go
type Keyish struct {
	Foo string
	Bar string
}

atl := atlas.MustBuild(
	atlas.BuildEntry(Keyish{}).Transform().
		TransformMarshal(atlas.MakeMarshalTransformFunc(
			func(x Keyish) (string, error) { return x.Foo + x.Bar, nil })).
		TransformUnmarshal(atlas.MakeUnmarshalTransformFunc(
			func(x string) (Keyish, error) { return Keyish{x[0], x[1:]}, nil })).
		Complete(),
)

value := map[Keyish]string{{"k", "ey"}: "value"}

refmt.MarshalAtlased(json.EncodeOptions{}, value, atl)
// yields `{"key":"value"}`!

refmt.UnmarshalAtlased(json.DecodeOptions{}, `{"key":"value"}`, &map[Keyish]string{}, atl)
// gives you back the map with `Keyish{"k", "ey"}` as a key!
```

You can, of course, do anything in those transform funcs.  (Probably you should parse a little more robustly than this dummy example!)
