### PR TITLE
Unions!

### DIFF
--- a/obj/atlas/atlasEntry.go
+++ b/obj/atlas/atlasEntry.go
@@ -86,6 +86,10 @@ type AtlasEntry struct {
 	// Only valid if `this.Type.Kind() == Map`.
 	MapMorphism *MapMorphism
 
+	// Configuration for how to pick concrete types to fill a union interface.
+	// Only valid if `this.Type.Kind() == Interface`.
+	UnionKeyedMorphism *UnionKeyedMorphism
+
 	// FUTURE: enum-ish primitives, multiplexers for interfaces,
 	//  lots of such things will belong here.
 
@@ -105,7 +109,11 @@ type AtlasEntry struct {
 func BuildEntry(typeHintObj interface{}) *BuilderCore {
 	rt := reflect.TypeOf(typeHintObj)
 	if rt.Kind() == reflect.Ptr {
-		panic("invalid atlas build: use the bare object, not a pointer (refmt will handle pointers automatically)")
+		if rt.Elem().Kind() == reflect.Interface {
+			rt = rt.Elem()
+		} else {
+			panic("invalid atlas build: use the bare object, not a pointer (refmt will handle pointers automatically)")
+		}
 	}
 	return &BuilderCore{
 		&AtlasEntry{Type: rt},

--- a/obj/atlas/unionMorphism.go
+++ b/obj/atlas/unionMorphism.go
@@ -3,11 +3,14 @@ package atlas
 import (
 	"fmt"
 	"reflect"
+	"sort"
 )
 
 type UnionKeyedMorphism struct {
 	// Mapping of typehint key strings to atlasEntry that should be delegated to.
 	Elements map[string]*AtlasEntry
+	// Mapping of rtid to string (roughly the dual of the Elements map).
+	Mappings map[uintptr]string
 	// Purely to have in readiness for error messaging.
 	KnownMembers []string
 }
@@ -16,7 +19,10 @@ func (x *BuilderCore) KeyedUnion() *BuilderUnionKeyedMorphism {
 	if x.entry.Type.Kind() != reflect.Interface {
 		panic(fmt.Errorf("cannot use union morphisms for type %q, which is kind %s", x.entry.Type, x.entry.Type.Kind()))
 	}
-	x.entry.UnionKeyedMorphism = &UnionKeyedMorphism{}
+	x.entry.UnionKeyedMorphism = &UnionKeyedMorphism{
+		Elements: make(map[string]*AtlasEntry),
+		Mappings: make(map[uintptr]string),
+	}
 	return &BuilderUnionKeyedMorphism{x.entry}
 }
 
@@ -25,9 +31,15 @@ type BuilderUnionKeyedMorphism struct {
 }
 
 func (x *BuilderUnionKeyedMorphism) Of(elements map[string]*AtlasEntry) *AtlasEntry {
-	x.entry.UnionKeyedMorphism.Elements = elements
-	// FIXME: do a copy loop plus sanity check that all the delegates are... well struct or map machines really, but definitely blacklisting other delegating machinery.
-	// FIXME: and sanity check that they can all be assigned to the interface ffs.
-	// FIXME: populate KnownMembers at the same time.
+	cfg := x.entry.UnionKeyedMorphism
+	for hint, ent := range elements {
+		// FIXME: check that all the delegates are... well struct or map machines really, but definitely blacklisting other delegating machinery.
+		// FIXME: and sanity check that they can all be assigned to the interface ffs.
+
+		cfg.Elements[hint] = ent
+		cfg.Mappings[reflect.ValueOf(ent.Type).Pointer()] = hint
+		cfg.KnownMembers = append(cfg.KnownMembers, hint)
+	}
+	sort.Strings(cfg.KnownMembers)
 	return x.entry
 }

--- a/obj/atlas/unionMorphism.go
+++ b/obj/atlas/unionMorphism.go
@@ -1,0 +1,33 @@
+package atlas
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type UnionKeyedMorphism struct {
+	// Mapping of typehint key strings to atlasEntry that should be delegated to.
+	Elements map[string]*AtlasEntry
+	// Purely to have in readiness for error messaging.
+	KnownMembers []string
+}
+
+func (x *BuilderCore) KeyedUnion() *BuilderUnionKeyedMorphism {
+	if x.entry.Type.Kind() != reflect.Interface {
+		panic(fmt.Errorf("cannot use union morphisms for type %q, which is kind %s", x.entry.Type, x.entry.Type.Kind()))
+	}
+	x.entry.UnionKeyedMorphism = &UnionKeyedMorphism{}
+	return &BuilderUnionKeyedMorphism{x.entry}
+}
+
+type BuilderUnionKeyedMorphism struct {
+	entry *AtlasEntry
+}
+
+func (x *BuilderUnionKeyedMorphism) Of(elements map[string]*AtlasEntry) *AtlasEntry {
+	x.entry.UnionKeyedMorphism.Elements = elements
+	// FIXME: do a copy loop plus sanity check that all the delegates are... well struct or map machines really, but definitely blacklisting other delegating machinery.
+	// FIXME: and sanity check that they can all be assigned to the interface ffs.
+	// FIXME: populate KnownMembers at the same time.
+	return x.entry
+}

--- a/obj/errors.go
+++ b/obj/errors.go
@@ -57,3 +57,16 @@ type ErrNoSuchField struct {
 func (e ErrNoSuchField) Error() string {
 	return fmt.Sprintf("unmarshal error: no such field named %s", e.Name)
 }
+
+// ErrNoSuchUnionMember is the error returned when unmarshalling into a union
+// interface and the token stream contains a key which does not name any of the
+// known members of the union.
+type ErrNoSuchUnionMember struct {
+	Name         string       // Key name from the token.
+	Type         reflect.Type // The interface type we're trying to fill.
+	KnownMembers []string     // Members we expected isntead.
+}
+
+func (e ErrNoSuchUnionMember) Error() string {
+	return fmt.Sprintf("unmarshal error: cannot unmarshal into union %s: %q is not one of the known members (expected one of %s)", e.Type, e.Name, e.KnownMembers)
+}

--- a/obj/marshal.go
+++ b/obj/marshal.go
@@ -52,6 +52,8 @@ type MarshalMachine interface {
 	Step(*Marshaller, *marshalSlab, *Token) (done bool, err error)
 }
 
+type marshalMachineStep func(*Marshaller, *marshalSlab, *Token) (done bool, err error)
+
 func (d *Marshaller) Step(tok *Token) (bool, error) {
 	tok.Tagged = false
 	//	fmt.Printf("> next step is %#v\n", d.step)

--- a/obj/marshalUnionKeyed.go
+++ b/obj/marshalUnionKeyed.go
@@ -1,0 +1,71 @@
+package obj
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/polydawn/refmt/obj/atlas"
+	. "github.com/polydawn/refmt/tok"
+)
+
+type marshalMachineUnionKeyed struct {
+	cfg *atlas.AtlasEntry // set on initialization
+
+	target_rv   reflect.Value // the element (interface already unwrapped).
+	elementName string        // the serial name for this union member type.
+
+	step     marshalMachineStep
+	delegate MarshalMachine // actual machine, picked based on content of the interface.
+}
+
+func (mach *marshalMachineUnionKeyed) Reset(slab *marshalSlab, rv reflect.Value, rt reflect.Type) error {
+	mach.target_rv = rv.Elem()
+	if mach.target_rv.Kind() == reflect.Invalid {
+		return fmt.Errorf("nil is not a valid member for the union for interface %q", mach.cfg.Type.Name())
+	}
+	element_rt := mach.target_rv.Type()
+	mach.elementName = mach.cfg.UnionKeyedMorphism.Mappings[reflect.ValueOf(element_rt).Pointer()]
+	if mach.elementName == "" {
+		return fmt.Errorf("type %q is not one of the known members of the union for interface %q", element_rt.Name(), mach.cfg.Type.Name())
+	}
+	delegateAtlasEnt := mach.cfg.UnionKeyedMorphism.Elements[mach.elementName]
+	mach.delegate = _yieldMarshalMachinePtrForAtlasEntry(slab.tip(), delegateAtlasEnt, slab.atlas)
+	if err := mach.delegate.Reset(slab, mach.target_rv, delegateAtlasEnt.Type); err != nil {
+		return err
+	}
+	mach.step = mach.step_emitMapOpen
+	return nil
+}
+
+func (mach *marshalMachineUnionKeyed) Step(driver *Marshaller, slab *marshalSlab, tok *Token) (done bool, err error) {
+	return mach.step(driver, slab, tok)
+}
+
+func (mach *marshalMachineUnionKeyed) step_emitMapOpen(driver *Marshaller, slab *marshalSlab, tok *Token) (done bool, err error) {
+	tok.Type = TMapOpen
+	tok.Length = 1
+	mach.step = mach.step_emitKey
+	return false, nil
+}
+
+func (mach *marshalMachineUnionKeyed) step_emitKey(driver *Marshaller, slab *marshalSlab, tok *Token) (done bool, err error) {
+	tok.Type = TString
+	tok.Str = mach.elementName
+	mach.step = mach.step_delegate
+	return false, nil
+}
+
+func (mach *marshalMachineUnionKeyed) step_delegate(driver *Marshaller, slab *marshalSlab, tok *Token) (done bool, err error) {
+	done, err = mach.delegate.Step(driver, slab, tok)
+	if done && err == nil {
+		mach.step = mach.step_emitMapClose
+		return false, nil
+	}
+	return
+}
+
+func (mach *marshalMachineUnionKeyed) step_emitMapClose(driver *Marshaller, slab *marshalSlab, tok *Token) (done bool, err error) {
+	tok.Type = TMapClose
+	mach.step = nil
+	return true, nil
+}

--- a/obj/objSuite_union_test.go
+++ b/obj/objSuite_union_test.go
@@ -33,10 +33,17 @@ func TestUnionHandling(t *testing.T) {
 			/**/ {Type: TMapClose},
 			{Type: TMapClose},
 		}
+		t.Run("marshal", func(t *testing.T) {
+			var value WowUnion = WowAlpha{"v1", "v2"}
+			checkMarshalling(t, atl, &value, seq, nil)
+		})
 		t.Run("unmarshal", func(t *testing.T) {
 			var slot WowUnion
 			var expect WowUnion = WowAlpha{"v1", "v2"}
 			checkUnmarshalling(t, atl, &slot, seq, &expect, nil)
 		})
+		// TODO marshalling without the pointer grab *doesn't* work, because it doesn't get the interface info.
+		//   this is inevitable.. but the error messages here need work, because it's extremely easy to typo or just not know about this detail of Go.
+		//checkMarshalling(t, atl, value, seq, nil)
 	})
 }

--- a/obj/objSuite_union_test.go
+++ b/obj/objSuite_union_test.go
@@ -1,0 +1,42 @@
+package obj
+
+import (
+	"testing"
+
+	"github.com/polydawn/refmt/obj/atlas"
+	. "github.com/polydawn/refmt/tok"
+)
+
+func TestUnionHandling(t *testing.T) {
+	t.Run("hello union keyed", func(t *testing.T) {
+		type WowUnion interface{} // unions with marker methods are even better, but we can't use non-top-level types for those so most of the tests don't do it.
+		type WowAlpha struct {
+			A1 string
+			A2 string
+		}
+		type WowBeta struct {
+			B1 string
+			B2 string
+		}
+		atl := atlas.MustBuild(
+			atlas.BuildEntry((*WowUnion)(nil)).KeyedUnion().
+				Of(map[string]*atlas.AtlasEntry{
+					"alpha": atlas.BuildEntry(WowAlpha{}).StructMap().Autogenerate().Complete(),
+					"beta":  atlas.BuildEntry(WowBeta{}).StructMap().Autogenerate().Complete(),
+				}),
+		)
+		seq := []Token{
+			{Type: TMapOpen, Length: 1},
+			TokStr("alpha"), {Type: TMapOpen, Length: 2},
+			/**/ TokStr("a1"), TokStr("v1"),
+			/**/ TokStr("a2"), TokStr("v2"),
+			/**/ {Type: TMapClose},
+			{Type: TMapClose},
+		}
+		t.Run("unmarshal", func(t *testing.T) {
+			var slot WowUnion
+			var expect WowUnion = WowAlpha{"v1", "v2"}
+			checkUnmarshalling(t, atl, &slot, seq, &expect, nil)
+		})
+	})
+}

--- a/obj/unmarshalUnionKeyed.go
+++ b/obj/unmarshalUnionKeyed.go
@@ -1,0 +1,88 @@
+package obj
+
+import (
+	"reflect"
+
+	"github.com/polydawn/refmt/obj/atlas"
+	. "github.com/polydawn/refmt/tok"
+)
+
+type unmarshalMachineUnionKeyed struct {
+	cfg *atlas.UnionKeyedMorphism // set on initialization
+
+	target_rv reflect.Value
+	target_rt reflect.Type
+
+	step     unmarshalMachineStep
+	tmp_rv   reflect.Value
+	delegate UnmarshalMachine // actual machine, once we've demuxed with the second token (the key).
+}
+
+func (mach *unmarshalMachineUnionKeyed) Reset(_ *unmarshalSlab, rv reflect.Value, rt reflect.Type) error {
+	mach.target_rv = rv
+	mach.target_rt = rt
+	mach.step = mach.acceptMapOpen
+	return nil
+}
+
+func (mach *unmarshalMachineUnionKeyed) Step(driver *Unmarshaller, slab *unmarshalSlab, tok *Token) (done bool, err error) {
+	return mach.step(driver, slab, tok)
+}
+
+func (mach *unmarshalMachineUnionKeyed) acceptMapOpen(driver *Unmarshaller, slab *unmarshalSlab, tok *Token) (done bool, err error) {
+	switch tok.Type {
+	case TMapOpen:
+		switch tok.Length {
+		case -1: // pass
+		case 1: // correct
+		default:
+			return true, ErrMalformedTokenStream{tok.Type, "unions in keyed format must be maps with exactly one entry"} // FIXME not malformed per se
+		}
+		mach.step = mach.acceptKey
+		return false, nil
+	// REVIEW: is case TNull perhaps conditionally acceptable?
+	default:
+		return true, ErrMalformedTokenStream{tok.Type, "start of union value"} // FIXME not malformed per se
+	}
+}
+
+func (mach *unmarshalMachineUnionKeyed) acceptKey(driver *Unmarshaller, slab *unmarshalSlab, tok *Token) (done bool, err error) {
+	switch tok.Type {
+	case TString:
+		// Look up the configuration for this key.
+		delegateAtlasEnt, ok := mach.cfg.Elements[tok.Str]
+		if !ok {
+			return true, ErrNoSuchUnionMember{tok.Str, mach.target_rt, mach.cfg.KnownMembers}
+		}
+		// Allocate a new concrete value, and hang on to that rv handle.
+		//  Assigning into the interface must be done at the end if it's a non-pointer.
+		mach.tmp_rv = reflect.New(delegateAtlasEnt.Type).Elem()
+		// Get and configure a machine for the delegation.
+		delegate := _yieldUnmarshalMachinePtrForAtlasEntry(slab.tip(), delegateAtlasEnt, slab.atlas)
+		delegate.Reset(slab, mach.tmp_rv, delegateAtlasEnt.Type)
+		mach.delegate = delegate
+		mach.step = mach.doDelegate
+		return false, nil
+	default:
+		return true, ErrMalformedTokenStream{tok.Type, "map key"}
+	}
+}
+
+func (mach *unmarshalMachineUnionKeyed) doDelegate(driver *Unmarshaller, slab *unmarshalSlab, tok *Token) (done bool, err error) {
+	done, err = mach.delegate.Step(driver, slab, tok)
+	if done && err == nil {
+		mach.step = mach.acceptMapClose
+		return false, nil
+	}
+	return
+}
+
+func (mach *unmarshalMachineUnionKeyed) acceptMapClose(driver *Unmarshaller, slab *unmarshalSlab, tok *Token) (done bool, err error) {
+	switch tok.Type {
+	case TMapClose:
+		mach.target_rv.Set(mach.tmp_rv)
+		return true, nil
+	default:
+		return true, ErrMalformedTokenStream{tok.Type, "map close at end of union value"}
+	}
+}

--- a/obj/unmarshalUnionKeyed.go
+++ b/obj/unmarshalUnionKeyed.go
@@ -59,7 +59,9 @@ func (mach *unmarshalMachineUnionKeyed) acceptKey(driver *Unmarshaller, slab *un
 		mach.tmp_rv = reflect.New(delegateAtlasEnt.Type).Elem()
 		// Get and configure a machine for the delegation.
 		delegate := _yieldUnmarshalMachinePtrForAtlasEntry(slab.tip(), delegateAtlasEnt, slab.atlas)
-		delegate.Reset(slab, mach.tmp_rv, delegateAtlasEnt.Type)
+		if err := delegate.Reset(slab, mach.tmp_rv, delegateAtlasEnt.Type); err != nil {
+			return true, err
+		}
 		mach.delegate = delegate
 		mach.step = mach.doDelegate
 		return false, nil


### PR DESCRIPTION
Refmt supports unions now!  If you have a part of your serial data which should be parsed as one of an enumerable set of different structures, we can do that.

You can define a grouping interface, like this:

```go
type WowUnion interface{
	_WowUnionMarker() // optional, but useful for more compile-time checks :)
}
```

Then a variety of structs:

```go
type WowAlpha struct {
	A1 string
	A2 string
}
type WowBeta struct {
	B1 string
	B2 string
}

func (WowAlpha) _WowUnionMarker() {}
func (WowBeta) _WowUnionMarker() {}
```

Then define an atlas that understands the union type like this:

```go
atl := atlas.MustBuild(
	atlas.BuildEntry((*WowUnion)(nil)).KeyedUnion().
		Of(map[string]*atlas.AtlasEntry{
			"alpha": atlas.BuildEntry(WowAlpha{}).StructMap().Autogenerate().Complete(),
			"beta":  atlas.BuildEntry(WowBeta{}).StructMap().Autogenerate().Complete(),
		}),
)
```

(The `(*WowUnion)(nil)` dance is the standard way to get the type info for a typed interface shoveled into an `interface{}` -- it's doing the same thing as the `WowAlpha{}` references do for building atlas info about structs: just providing type info.  It's a tad odd looking, but this is the best syntax available for the pattern in Go, to the best of my knowledge.)

Now you can round-trip serialize a value like this:

```go
var WowUnion = WowAlpha{
	A1: "wow",
	A2: "magic",
}
```

With JSON like this:

```json
{
	"alpha": {
		"a1": "wow",
		"a2": "magic"
	}
}
```

Hooray!  Polymorphism!

If you weren't using Refmt, the only way to do this with most other Go serialization libraries is with a union-ish struct like this:

```go
type WowUnionTheSadWay struct {
	Alpha *WowAlpha `json:",omitempty"`
	Beta  *WowBeta  `json:",omitempty"`
}
```

... and while this works, it's pretty frustrating to code around, because the baggage of verifying only one of them is set is still on the author rather than handled sanely by the library.

Refmt can now do better than this, because we explicitly understand what a union is and make semantic checks appropriately; and since we put values in an interface, there's a single value upon which your Go code can use type switches.  Much, much better.

Currently, this serial layout is the only one supported, but more formats are coming in the future; it's called "UnionKeyed" rather than just plain "Union" for a reason.  This "UnionKeyed" layout is the one first I'm implementing because I think it's the most excellent if you have any freedom of choice in your protocol layout; this is the only pattern of serial layout for union-like objects that can be parsed in a streaming straight shot with no possible need for buffering, and that's a heck of a virtue.  Adding more styles of union serialization should be pretty easy now that the possibility is proven out (though other styles will almost certainly require adding another new machine, since buffering behavior has very different performance characteristics and thus shouldn't be evaluated unless needed).
