### PR TITLE
add support for checking if a struct is empty

### DIFF
--- a/obj/empty_test.go
+++ b/obj/empty_test.go
@@ -1,0 +1,26 @@
+package obj
+
+import (
+	"reflect"
+	"testing"
+)
+
+type T1 struct{}
+
+type T2 struct {
+	array []byte
+}
+type T3 struct {
+	array []*T3
+}
+
+func TestIsEmptyValue(t *testing.T) {
+	isEmpty := func(v interface{}) {
+		if !isEmptyValue(reflect.ValueOf(v)) {
+			t.Fatalf("expected value of type %T to be empty", v)
+		}
+	}
+	isEmpty(T1{})
+	isEmpty(T2{})
+	isEmpty(T3{})
+}


### PR DESCRIPTION
(used by the `omitempty` tag)

Rational: Even if it's slow, we only hit this if the user has *explicitly* asked us to omit the empty struct (via `omitempty`). Not doing this is, IMO, a bug.