### PR TITLE
add a test for round-tripping a nil slice to a slice

### DIFF
--- a/obj/objFixtures_test.go
+++ b/obj/objFixtures_test.go
@@ -440,6 +440,8 @@ var objFixtures = []struct {
 				valueFn: func() interface{} { return [0]interface{}{} }},
 			{title: "from iface slice",
 				valueFn: func() interface{} { return []interface{}{} }},
+			{title: "from nil iface slice",
+				valueFn: func() interface{} { return []interface{}(nil) }},
 		},
 		unmarshalResults: []unmarshalResults{
 			{title: "into string",
@@ -961,7 +963,7 @@ var objFixtures = []struct {
 	{title: "empty",
 		sequence:       fixtures.SequenceMap["empty"],
 		marshalResults: []marshalResults{
-		// not much marshals to empty!
+			// not much marshals to empty!
 		},
 		unmarshalResults: []unmarshalResults{
 			{title: "into string",


### PR DESCRIPTION
Basically, when encoding:

```go
struct { Thing []int } { Thing: nil }
```

I'm seeing `{thing: null}` (fine) and then when I try *decoding* this back in to
the same struct I get the error:

> unmarshal error: cannot assign <0> to slice field

(no bueno)