### PR TITLE
decode CBOR's undefined to null

### DIFF
--- a/cbor/cborDecoder.go
+++ b/cbor/cborDecoder.go
@@ -178,7 +178,7 @@ func (d *Decoder) step_acceptMapValue(tokenSlot *Token) (done bool, err error) {
 
 func (d *Decoder) stepHelper_acceptValue(majorByte byte, tokenSlot *Token) (done bool, err error) {
 	switch majorByte {
-	case cborSigilNil:
+	case cborSigilNil, cborSigilUndefined:
 		tokenSlot.Type = TNull
 		return true, nil
 	case cborSigilFalse:


### PR DESCRIPTION
Bleh. We're not going to round-trip this but we shouldn't hit this anyways.

Alternatively, we could just return an error. However, that may break things for some users...

fixes #43

(needs test)