### PR TITLE
Unmarshalling without type info should prefer int.

### DIFF
--- a/obj/unmarshalBuiltins.go
+++ b/obj/unmarshalBuiltins.go
@@ -159,9 +159,9 @@ func (mach *unmarshalMachinePrimitive) Step(_ *Unmarshaller, _ *unmarshalSlab, t
 		case TBool:
 			mach.rv.Set(reflect.ValueOf(tok.Bool))
 		case TInt:
-			mach.rv.Set(reflect.ValueOf(tok.Int))
+			mach.rv.Set(reflect.ValueOf(int(tok.Int))) // Unmarshalling with no particular type info should default to using plain 'int' whenever viable.
 		case TUint:
-			mach.rv.Set(reflect.ValueOf(tok.Uint))
+			mach.rv.Set(reflect.ValueOf(int(tok.Uint))) // Unmarshalling with no particular type info should default to using plain 'int' whenever viable.
 		case TFloat64:
 			mach.rv.Set(reflect.ValueOf(tok.Float64))
 		case TNull:


### PR DESCRIPTION
Unmarshalling without type info should prefer int.

Plainer is better.

This addresses some odd behaviors in that the CBOR unmarshal and JSON unmarshal would behave differently when targeting an empty interface: JSON would yield int64, while CBOR would yield *uint64*, due to CBOR's Interesting (ahem) Opinions about signedness of numbers.

Now both unmarshallers will simply yield `int`.  This is probably less surprising in almost all cases.  More importantly, it's consistent.

If unmarshalling into a concrete type that uses `uint64`, etc, those unmarshallings will of course not pass through this cast; therefore, if handling numbers that require those biggest bits of precision, perhaps your code shouldn't be trying to work without types.

(PRs to make this do bigger types when overflow would be encountered would be accepted; I just have no spoons for overflow issues today, since the goal I'm actually trying to get to is some performance improvements, and this is just a very ugly, hairy yak I had to shave along the way to getting there.)