### PR TITLE
Rewrite obj unmarshaller components to avoid use of fnptrs.

### DIFF
--- a/obj/unmarshal.go
+++ b/obj/unmarshal.go
@@ -54,8 +54,6 @@ type UnmarshalMachine interface {
 	Step(*Unmarshaller, *unmarshalSlab, *Token) (done bool, err error)
 }
 
-type unmarshalMachineStep func(*Unmarshaller, *unmarshalSlab, *Token) (done bool, err error)
-
 func (d *Unmarshaller) Step(tok *Token) (bool, error) {
 	done, err := d.step.Step(d, &d.unmarshalSlab, tok)
 	// If the step errored: out, entirely.

--- a/obj/unmarshalMapWildcard.go
+++ b/obj/unmarshalMapWildcard.go
@@ -15,9 +15,17 @@ type unmarshalMachineMapStringWildcard struct {
 	key_rv        reflect.Value                // Addressable handle to a slot for keys to unmarshal into.
 	keyDestringer atlas.UnmarshalTransformFunc // Transform str->foo, to be used if keys are not plain strings.
 	tmp_rv        reflect.Value                // Addressable handle to a slot for values to unmarshal into.
-	step          unmarshalMachineStep
-	haveValue     bool // Piece of attendant state to help know we've been through at least one k=v pair so we can post-v store it.
+	phase         unmarshalMachineMapStringWildcardPhase
 }
+
+type unmarshalMachineMapStringWildcardPhase uint8
+
+const (
+	unmarshalMachineMapStringWildcardPhase_initial          unmarshalMachineMapStringWildcardPhase = iota
+	unmarshalMachineMapStringWildcardPhase_acceptKeyOrClose                                        // doesn't commit prev value
+	unmarshalMachineMapStringWildcardPhase_acceptValue
+	unmarshalMachineMapStringWildcardPhase_acceptAnotherKeyOrClose
+)
 
 func (mach *unmarshalMachineMapStringWildcard) Reset(slab *unmarshalSlab, rv reflect.Value, rt reflect.Type) error {
 	mach.target_rv = rv
@@ -34,13 +42,22 @@ func (mach *unmarshalMachineMapStringWildcard) Reset(slab *unmarshalSlab, rv ref
 		mach.keyDestringer = atlEnt.UnmarshalTransformFunc
 	}
 	mach.tmp_rv = reflect.New(mach.value_rt).Elem()
-	mach.step = mach.step_Initial
-	mach.haveValue = false
+	mach.phase = unmarshalMachineMapStringWildcardPhase_initial
 	return nil
 }
 
 func (mach *unmarshalMachineMapStringWildcard) Step(driver *Unmarshaller, slab *unmarshalSlab, tok *Token) (done bool, err error) {
-	return mach.step(driver, slab, tok)
+	switch mach.phase {
+	case unmarshalMachineMapStringWildcardPhase_initial:
+		return mach.step_Initial(driver, slab, tok)
+	case unmarshalMachineMapStringWildcardPhase_acceptKeyOrClose:
+		return mach.step_AcceptKeyOrClose(driver, slab, tok)
+	case unmarshalMachineMapStringWildcardPhase_acceptValue:
+		return mach.step_AcceptValue(driver, slab, tok)
+	case unmarshalMachineMapStringWildcardPhase_acceptAnotherKeyOrClose:
+		return mach.step_AcceptAnotherKeyOrClose(driver, slab, tok)
+	}
+	panic("unreachable")
 }
 
 func (mach *unmarshalMachineMapStringWildcard) step_Initial(_ *Unmarshaller, _ *unmarshalSlab, tok *Token) (done bool, err error) {
@@ -52,7 +69,7 @@ func (mach *unmarshalMachineMapStringWildcard) step_Initial(_ *Unmarshaller, _ *
 		return true, nil
 	case TMapOpen:
 		// Great.  Consumed.
-		mach.step = mach.step_AcceptKey
+		mach.phase = unmarshalMachineMapStringWildcardPhase_acceptKeyOrClose
 		// Initialize the map if it's nil.
 		if mach.target_rv.IsNil() {
 			mach.target_rv.Set(reflect.MakeMap(mach.target_rv.Type()))
@@ -69,14 +86,8 @@ func (mach *unmarshalMachineMapStringWildcard) step_Initial(_ *Unmarshaller, _ *
 	}
 }
 
-func (mach *unmarshalMachineMapStringWildcard) step_AcceptKey(_ *Unmarshaller, slab *unmarshalSlab, tok *Token) (done bool, err error) {
-	// First, save any refs from the last value.
-	//  (This is fiddly: the delay comes mostly from the handling of slices, which may end up re-allocating
-	//   themselves during their decoding.)
-	if mach.haveValue {
-		mach.target_rv.SetMapIndex(mach.key_rv, mach.tmp_rv)
-	}
-	// Now switch on tokens.
+func (mach *unmarshalMachineMapStringWildcard) step_AcceptKeyOrClose(_ *Unmarshaller, slab *unmarshalSlab, tok *Token) (done bool, err error) {
+	// Switch on tokens.
 	switch tok.Type {
 	case TMapOpen:
 		return true, fmt.Errorf("unexpected mapOpen; expected map key")
@@ -102,7 +113,7 @@ func (mach *unmarshalMachineMapStringWildcard) step_AcceptKey(_ *Unmarshaller, s
 		if err = mach.mustAcceptKey(mach.key_rv); err != nil {
 			return true, err
 		}
-		mach.step = mach.step_AcceptValue
+		mach.phase = unmarshalMachineMapStringWildcardPhase_acceptValue
 		return false, nil
 	default:
 		return true, fmt.Errorf("unexpected token %s; expected key string or end of map", tok)
@@ -117,13 +128,22 @@ func (mach *unmarshalMachineMapStringWildcard) mustAcceptKey(key_rv reflect.Valu
 }
 
 func (mach *unmarshalMachineMapStringWildcard) step_AcceptValue(driver *Unmarshaller, slab *unmarshalSlab, tok *Token) (done bool, err error) {
-	mach.step = mach.step_AcceptKey
+	mach.phase = unmarshalMachineMapStringWildcardPhase_acceptAnotherKeyOrClose
 	mach.tmp_rv.Set(reflect.Zero(mach.value_rt))
-	mach.haveValue = true
 	return false, driver.Recurse(
 		tok,
 		mach.tmp_rv,
 		mach.value_rt,
 		mach.valueMach,
 	)
+}
+
+func (mach *unmarshalMachineMapStringWildcard) step_AcceptAnotherKeyOrClose(_ *Unmarshaller, slab *unmarshalSlab, tok *Token) (done bool, err error) {
+	// First, save any refs from the last value.
+	//  (This is fiddly: the delay comes mostly from the handling of slices, which may end up re-allocating
+	//   themselves during their decoding.)
+	mach.target_rv.SetMapIndex(mach.key_rv, mach.tmp_rv)
+
+	// The rest is the same as the very first acceptKeyOrClose (and has the same future state transitions).
+	return mach.step_AcceptKeyOrClose(nil, slab, tok)
 }


### PR DESCRIPTION
Similar to #49, but now on the `obj` package.

Also tossed in a few other targets of opportunity whilst the mem profiling was in front of me.

The individual commits have more benchmark info in the messages, but tl;dr... combined with the improvements in #49, our aggregate performance is...

- ~25% faster to unmarshalling cbor maps
- ~66% fewer allocs during unmarshalling cbor maps
- ~33% fewer bytes allocated during unmarshalling cbor maps

Not bad.

Handling of arrays and slices also got some nice buffs, though smaller, since the issues were already fairly amortized in their cases, coincidentally.

Most of the `alloc_objects` graph is now full of zeros, which is very pleasing.  Most of the remaining allocations are pushed to the leafmost nodes (most of those are unavoidable; some we might still be able to batch up or something, but it'll be a different category of improvement than these here).

Future work might include some refactors to add methods simply to better mark whats going on in some of the remaining areas.  For example, `unmarshalMachineWildcard.prepareDemux` is one of the remaining alloc sites... but that's because it's legitimately doing a `make(map[string]interface{})` which is the nature of the work; it's no accident.  Similarly, `marshalMachineMapWildcard.Reset` does a lot of work... but that's because it's doing a sort of the keys during that initialization, and this is again no accident, and the nature of the work.

Interestingly, while we've been chasing the use of function pointers (which unintentionally generated closures) out of the code base, it turns out the use of MarshalMachine/UnmarshalMachine pointers gleaned from the slabs has been completely fine, and zero-alloc, as intended.  So, though it *looks* a lot like the delegationy pattern that's been problematic, it's actually doing something very different, and it doesn't need a refactor at all.  (Arguably we could flatten all these statemachines into *one* with a single const table -- and maybe I'll do that when picking back up the 'objv3' branch, which is languishing on the side for lack of time -- but not today, and it's unclear if that would be any sizable improvement.  Almost certainly there are yet other bigger fish to fry first.)

Note that all of these numbers are data-dependent.  The overall speed and memory usage in your applications will vary based on the size of strings, nesting depth of content, number of maps versus number of lists, and so on and so on.  These numbers only mean one thing for sure: "better".